### PR TITLE
add inline specifiers

### DIFF
--- a/Common/UtilNPP/Exceptions.h
+++ b/Common/UtilNPP/Exceptions.h
@@ -129,7 +129,7 @@ namespace npp
     /// \param rOutputStream The stream the exception information is written to.
     /// \param rException The exception that's being written.
     /// \return Reference to the output stream being used.
-    std::ostream &
+    inline std::ostream &
     operator << (std::ostream &rOutputStream, const Exception &rException)
     {
         rOutputStream << rException.toString();

--- a/Common/UtilNPP/Image.h
+++ b/Common/UtilNPP/Image.h
@@ -137,13 +137,13 @@ namespace npp
             Size oSize_;
     };
 
-    bool
+    inline bool
     operator== (const Image::Size &rFirst, const Image::Size &rSecond)
     {
         return rFirst.nWidth == rSecond.nWidth && rFirst.nHeight == rSecond.nHeight;
     }
 
-    bool
+    inline bool
     operator!= (const Image::Size &rFirst, const Image::Size &rSecond)
     {
         return rFirst.nWidth != rSecond.nWidth || rFirst.nHeight != rSecond.nHeight;


### PR DESCRIPTION
It causes error without "inline" or "static" specifiers when the header is included into two different source files. I find a similar concern [here](https://devtalk.nvidia.com/default/topic/1049649/cuda-programming-and-performance/possible-npp-bug-in-npp-operator-lt-lt-overloading/) 