### PR TITLE
Fix gcc version comparison in Makefiles

### DIFF
--- a/Samples/bf16TensorCoreGemm/Makefile
+++ b/Samples/bf16TensorCoreGemm/Makefile
@@ -287,12 +287,12 @@ ifeq ($(TARGET_OS),linux)
     GCCVERSION := $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f1 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f2 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f3 -d.)
-# Make sure the version number has at least 3 decimals
-    GCCVERSION += 00
+# Make sure the version number has at least 4 decimals
+    GCCVERSION += 000
 # Remove spaces from the version number
     GCCVERSION := $(subst $(space),$(empty),$(GCCVERSION))
-# Crop the version number to 3 decimals.
-    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-3)
+# Crop the version number to 4 decimals.
+    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-4)
 #$(warning $(GCCVERSION))
 
     IS_MIN_VERSION := $(shell expr `echo $(GCCVERSION)` \>= 500)

--- a/Samples/binaryPartitionCG/Makefile
+++ b/Samples/binaryPartitionCG/Makefile
@@ -281,12 +281,12 @@ ifeq ($(TARGET_OS),linux)
     GCCVERSION := $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f1 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f2 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f3 -d.)
-# Make sure the version number has at least 3 decimals
-    GCCVERSION += 00
+# Make sure the version number has at least 4 decimals
+    GCCVERSION += 000
 # Remove spaces from the version number
     GCCVERSION := $(subst $(space),$(empty),$(GCCVERSION))
-# Crop the version number to 3 decimals.
-    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-3)
+# Crop the version number to 4 decimals.
+    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-4)
 #$(warning $(GCCVERSION))
 
     IS_MIN_VERSION := $(shell expr `echo $(GCCVERSION)` \>= 470)

--- a/Samples/conjugateGradientMultiDeviceCG/Makefile
+++ b/Samples/conjugateGradientMultiDeviceCG/Makefile
@@ -299,12 +299,12 @@ ifeq ($(TARGET_OS),linux)
     GCCVERSION := $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f1 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f2 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f3 -d.)
-# Make sure the version number has at least 3 decimals
-    GCCVERSION += 00
+# Make sure the version number has at least 4 decimals
+    GCCVERSION += 000
 # Remove spaces from the version number
     GCCVERSION := $(subst $(space),$(empty),$(GCCVERSION))
-# Crop the version number to 3 decimals.
-    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-3)
+# Crop the version number to 4 decimals.
+    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-4)
 #$(warning $(GCCVERSION))
 
     IS_MIN_VERSION := $(shell expr `echo $(GCCVERSION)` \>= 470)

--- a/Samples/cudaNvSci/Makefile
+++ b/Samples/cudaNvSci/Makefile
@@ -292,12 +292,12 @@ ifeq ($(TARGET_OS),linux)
     GCCVERSION := $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f1 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f2 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f3 -d.)
-# Make sure the version number has at least 3 decimals
-    GCCVERSION += 00
+# Make sure the version number has at least 4 decimals
+    GCCVERSION += 000
 # Remove spaces from the version number
     GCCVERSION := $(subst $(space),$(empty),$(GCCVERSION))
-# Crop the version number to 3 decimals.
-    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-3)
+# Crop the version number to 4 decimals.
+    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-4)
 #$(warning $(GCCVERSION))
 
     IS_MIN_VERSION := $(shell expr `echo $(GCCVERSION)` \>= 470)

--- a/Samples/dmmaTensorCoreGemm/Makefile
+++ b/Samples/dmmaTensorCoreGemm/Makefile
@@ -287,12 +287,12 @@ ifeq ($(TARGET_OS),linux)
     GCCVERSION := $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f1 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f2 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f3 -d.)
-# Make sure the version number has at least 3 decimals
-    GCCVERSION += 00
+# Make sure the version number has at least 4 decimals
+    GCCVERSION += 000
 # Remove spaces from the version number
     GCCVERSION := $(subst $(space),$(empty),$(GCCVERSION))
-# Crop the version number to 3 decimals.
-    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-3)
+# Crop the version number to 4 decimals.
+    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-4)
 #$(warning $(GCCVERSION))
 
     IS_MIN_VERSION := $(shell expr `echo $(GCCVERSION)` \>= 500)

--- a/Samples/globalToShmemAsyncCopy/Makefile
+++ b/Samples/globalToShmemAsyncCopy/Makefile
@@ -281,12 +281,12 @@ ifeq ($(TARGET_OS),linux)
     GCCVERSION := $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f1 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f2 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f3 -d.)
-# Make sure the version number has at least 3 decimals
-    GCCVERSION += 00
+# Make sure the version number has at least 4 decimals
+    GCCVERSION += 000
 # Remove spaces from the version number
     GCCVERSION := $(subst $(space),$(empty),$(GCCVERSION))
-# Crop the version number to 3 decimals.
-    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-3)
+# Crop the version number to 4 decimals.
+    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-4)
 #$(warning $(GCCVERSION))
 
     IS_MIN_VERSION := $(shell expr `echo $(GCCVERSION)` \>= 500)

--- a/Samples/reduction/Makefile
+++ b/Samples/reduction/Makefile
@@ -281,12 +281,12 @@ ifeq ($(TARGET_OS),linux)
     GCCVERSION := $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f1 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f2 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f3 -d.)
-# Make sure the version number has at least 3 decimals
-    GCCVERSION += 00
+# Make sure the version number has at least 4 decimals
+    GCCVERSION += 000
 # Remove spaces from the version number
     GCCVERSION := $(subst $(space),$(empty),$(GCCVERSION))
-# Crop the version number to 3 decimals.
-    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-3)
+# Crop the version number to 4 decimals.
+    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-4)
 #$(warning $(GCCVERSION))
 
     IS_MIN_VERSION := $(shell expr `echo $(GCCVERSION)` \>= 470)

--- a/Samples/simpleAWBarrier/Makefile
+++ b/Samples/simpleAWBarrier/Makefile
@@ -287,12 +287,12 @@ ifeq ($(TARGET_OS),linux)
     GCCVERSION := $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f1 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f2 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f3 -d.)
-# Make sure the version number has at least 3 decimals
-    GCCVERSION += 00
+# Make sure the version number has at least 4 decimals
+    GCCVERSION += 000
 # Remove spaces from the version number
     GCCVERSION := $(subst $(space),$(empty),$(GCCVERSION))
-# Crop the version number to 3 decimals.
-    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-3)
+# Crop the version number to 4 decimals.
+    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-4)
 #$(warning $(GCCVERSION))
 
     IS_MIN_VERSION := $(shell expr `echo $(GCCVERSION)` \>= 500)

--- a/Samples/simpleVulkan/Makefile
+++ b/Samples/simpleVulkan/Makefile
@@ -309,12 +309,12 @@ ifeq ($(TARGET_OS),linux)
     GCCVERSION := $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f1 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f2 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f3 -d.)
-# Make sure the version number has at least 3 decimals
-    GCCVERSION += 00
+# Make sure the version number has at least 4 decimals
+    GCCVERSION += 000
 # Remove spaces from the version number
     GCCVERSION := $(subst $(space),$(empty),$(GCCVERSION))
-# Crop the version number to 3 decimals.
-    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-3)
+# Crop the version number to 4 decimals.
+    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-4)
 #$(warning $(GCCVERSION))
 
     IS_MIN_VERSION := $(shell expr `echo $(GCCVERSION)` \>= 470)

--- a/Samples/simpleVulkanMMAP/Makefile
+++ b/Samples/simpleVulkanMMAP/Makefile
@@ -311,12 +311,12 @@ ifeq ($(TARGET_OS),linux)
     GCCVERSION := $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f1 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f2 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f3 -d.)
-# Make sure the version number has at least 3 decimals
-    GCCVERSION += 00
+# Make sure the version number has at least 4 decimals
+    GCCVERSION += 000
 # Remove spaces from the version number
     GCCVERSION := $(subst $(space),$(empty),$(GCCVERSION))
-# Crop the version number to 3 decimals.
-    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-3)
+# Crop the version number to 4 decimals.
+    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-4)
 #$(warning $(GCCVERSION))
 
     IS_MIN_VERSION := $(shell expr `echo $(GCCVERSION)` \>= 470)

--- a/Samples/tf32TensorCoreGemm/Makefile
+++ b/Samples/tf32TensorCoreGemm/Makefile
@@ -287,12 +287,12 @@ ifeq ($(TARGET_OS),linux)
     GCCVERSION := $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f1 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f2 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f3 -d.)
-# Make sure the version number has at least 3 decimals
-    GCCVERSION += 00
+# Make sure the version number has at least 4 decimals
+    GCCVERSION += 000
 # Remove spaces from the version number
     GCCVERSION := $(subst $(space),$(empty),$(GCCVERSION))
-# Crop the version number to 3 decimals.
-    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-3)
+# Crop the version number to 4 decimals.
+    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-4)
 #$(warning $(GCCVERSION))
 
     IS_MIN_VERSION := $(shell expr `echo $(GCCVERSION)` \>= 500)

--- a/Samples/vulkanImageCUDA/Makefile
+++ b/Samples/vulkanImageCUDA/Makefile
@@ -309,12 +309,12 @@ ifeq ($(TARGET_OS),linux)
     GCCVERSION := $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f1 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f2 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f3 -d.)
-# Make sure the version number has at least 3 decimals
-    GCCVERSION += 00
+# Make sure the version number has at least 4 decimals
+    GCCVERSION += 000
 # Remove spaces from the version number
     GCCVERSION := $(subst $(space),$(empty),$(GCCVERSION))
-# Crop the version number to 3 decimals.
-    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-3)
+# Crop the version number to 4 decimals.
+    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-4)
 #$(warning $(GCCVERSION))
 
     IS_MIN_VERSION := $(shell expr `echo $(GCCVERSION)` \>= 470)

--- a/Samples/warpAggregatedAtomicsCG/Makefile
+++ b/Samples/warpAggregatedAtomicsCG/Makefile
@@ -275,12 +275,12 @@ ifeq ($(TARGET_OS),linux)
     GCCVERSION := $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f1 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f2 -d.)
     GCCVERSION += $(shell expr `echo $(GCCVERSIONSTRING)` | cut -f3 -d.)
-# Make sure the version number has at least 3 decimals
-    GCCVERSION += 00
+# Make sure the version number has at least 4 decimals
+    GCCVERSION += 000
 # Remove spaces from the version number
     GCCVERSION := $(subst $(space),$(empty),$(GCCVERSION))
-# Crop the version number to 3 decimals.
-    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-3)
+# Crop the version number to 4 decimals.
+    GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-4)
 #$(warning $(GCCVERSION))
 
     IS_MIN_VERSION := $(shell expr `echo $(GCCVERSION)` \>= 470)


### PR DESCRIPTION
The current gcc version check truncates to three digits. This fix uses four digits and allows gcc versions 10.0.0 and upward to work correctly.

Signed-off-by: Isaiah Grace <irgkenya4@gmail.com>