### PR TITLE
Avoid double frees in sample code

### DIFF
--- a/Samples/boxFilterNPP/boxFilterNPP.cpp
+++ b/Samples/boxFilterNPP/boxFilterNPP.cpp
@@ -167,9 +167,6 @@ int main(int argc, char *argv[]) {
     saveImage(sResultFilename, oHostDst);
     std::cout << "Saved image: " << sResultFilename << std::endl;
 
-    nppiFree(oDeviceSrc.data());
-    nppiFree(oDeviceDst.data());
-
     exit(EXIT_SUCCESS);
   } catch (npp::Exception &rException) {
     std::cerr << "Program error! The following exception occurred: \n";

--- a/Samples/cannyEdgeDetectorNPP/cannyEdgeDetectorNPP.cpp
+++ b/Samples/cannyEdgeDetectorNPP/cannyEdgeDetectorNPP.cpp
@@ -208,9 +208,6 @@ int main(int argc, char *argv[]) {
     saveImage(sResultFilename, oHostDst);
     std::cout << "Saved image: " << sResultFilename << std::endl;
 
-    nppiFree(oDeviceSrc.data());
-    nppiFree(oDeviceDst.data());
-
     exit(EXIT_SUCCESS);
   } catch (npp::Exception &rException) {
     std::cerr << "Program error! The following exception occurred: \n";


### PR DESCRIPTION
There are incorrect and unnecessary calls to nppiFree in two of the sample NPP applications (box filter and canny edge detector).

The device memory for the image will be automatically freed when the image destructor is called (i.e. when it goes out of scope at the end of the program). Explicitly freeing it separately causes an error on the call to nppiFree the same memory in the destructor for the image, as evidenced by running cuda-memcheck:
```
========= CUDA-MEMCHECK                                                                                                                                                                                                    
========= Program hit cudaErrorInvalidDevicePointer (error 17) due to "invalid device pointer" on CUDA API call to cudaFree.                                                                                               
=========     Saved host backtrace up to driver entry point at error                                                                                                                                                       
=========     Host Frame:/usr/lib/x86_64-linux-gnu/libcuda.so.1 [0x3451c3]                                                                                                                                                 
=========     Host Frame:/usr/local/cuda-8.0/targets/x86_64-linux/lib/libnppisu.so.8.0 [0x45616]                                                                                                                           
=========     Host Frame:./assignment_npp.exe [0x9835]                                                                                                                                                                     
=========     Host Frame:./assignment_npp.exe [0xa71b]                                                                                                                                                                     
=========     Host Frame:./assignment_npp.exe [0xa0ee]                                                                                                                                                                     
=========     Host Frame:./assignment_npp.exe [0x8d60]                                                                                                                                                                     
=========     Host Frame:/lib/x86_64-linux-gnu/libc.so.6 (__libc_start_main + 0xf0) [0x20840]                                                                                                                              
=========     Host Frame:./assignment_npp.exe [0x6bd9]                                                                                                                                                                     
=========                                                                                                                                                                                                                  
========= Program hit cudaErrorInvalidDevicePointer (error 17) due to "invalid device pointer" on CUDA API call to cudaFree.                                                                                               
=========     Saved host backtrace up to driver entry point at error                                                                                                                                                       
=========     Host Frame:/usr/lib/x86_64-linux-gnu/libcuda.so.1 [0x3451c3]                                                                                                                                                 
=========     Host Frame:/usr/local/cuda-8.0/targets/x86_64-linux/lib/libnppisu.so.8.0 [0x45616]                                                                                                                           
=========     Host Frame:./assignment_npp.exe [0x9835]                                                                                                                                                                     
=========     Host Frame:./assignment_npp.exe [0xa71b]                                                                                                                                                                     
=========     Host Frame:./assignment_npp.exe [0xa0ee]                                                                                                                                                                     
=========     Host Frame:./assignment_npp.exe [0x8d6c]                                                                                                                                                                     
=========     Host Frame:/lib/x86_64-linux-gnu/libc.so.6 (__libc_start_main + 0xf0) [0x20840]                                                                                                                              
=========     Host Frame:./assignment_npp.exe [0x6bd9]                                                                                                                                                                     
=========                                                                                                                                                                                                                  
========= ERROR SUMMARY: 2 errors                                                                                                                                                                                          
```