### PR TITLE
fix stringRemoveDelimiter to be able to parse '-h' argument

### DIFF
--- a/Common/helper_string.h
+++ b/Common/helper_string.h
@@ -100,7 +100,7 @@ inline int stringRemoveDelimiter(char delimiter, const char *string) {
     string_start++;
   }
 
-  if (string_start >= static_cast<int>(strlen(string) - 1)) {
+  if (string_start >= static_cast<int>(strlen(string))) {
     return 0;
   }
 


### PR DESCRIPTION
Without this fix, it won't parse '-h', '--h', etc.