### PR TITLE
Fixing issue #102: Compilation errors with clang 13 and OpenMP and MPI

### DIFF
--- a/Samples/0_Introduction/UnifiedMemoryStreams/Makefile
+++ b/Samples/0_Introduction/UnifiedMemoryStreams/Makefile
@@ -288,13 +288,24 @@ LIBRARIES :=
 # Attempt to compile a minimal OpenMP application. If a.out exists, OpenMP is properly set up.
 ifneq (,$(filter $(TARGET_OS),linux android))
 
+# Special treatment for Clang to not use standard OMP Library and fix OMP 5 bug in Clang 13
+ifneq (,$(findstring "clang",$(HOST_COMPILER)))
 ifneq (,$(filter $(TARGET_OS), android))
      LIBRARIES += -lomp
 else
      LIBRARIES += -lgomp
 endif
-
 ALL_CCFLAGS += -Xcompiler -fopenmp
+else
+      ALL_CCFLAGS += -Xcompiler -fopenmp
+      ALL_LDFLAGS += -Xcompiler -fopenmp
+      COMPILER_VERSION= $(shell $(HOST_COMPILER) --version)
+ifneq (,$(findstring 13.,$(COMPILER_VERSION)))
+      ALL_CCFLAGS += -Xcompiler -fopenmp -Xcompiler -fopenmp-version=45
+      ALL_LDFLAGS += -Xcompiler -fopenmp -Xcompiler -fopenmp-version=45
+endif
+endif
+
 $(shell echo "#include <omp.h>" > test.c ; echo "int main() { omp_get_num_threads(); return 0; }" >> test.c ; $(HOST_COMPILER) -fopenmp test.c)
 OPENMP ?= $(shell find a.out 2>/dev/null)
 

--- a/Samples/0_Introduction/cudaOpenMP/Makefile
+++ b/Samples/0_Introduction/cudaOpenMP/Makefile
@@ -294,13 +294,25 @@ LIBRARIES :=
 # Attempt to compile a minimal OpenMP application. If a.out exists, OpenMP is properly set up.
 ifneq (,$(filter $(TARGET_OS),linux android))
 
+
+# Special treatment for Clang to not use standard OMP Library and fix OMP 5 bug in Clang 13
+ifneq (,$(findstring "clang",$(HOST_COMPILER)))
 ifneq (,$(filter $(TARGET_OS), android))
      LIBRARIES += -lomp
 else
      LIBRARIES += -lgomp
 endif
-
 ALL_CCFLAGS += -Xcompiler -fopenmp
+else
+      ALL_CCFLAGS += -Xcompiler -fopenmp
+      ALL_LDFLAGS += -Xcompiler -fopenmp
+      COMPILER_VERSION= $(shell $(HOST_COMPILER) --version)
+ifneq (,$(findstring 13.,$(COMPILER_VERSION)))
+      ALL_CCFLAGS += -Xcompiler -fopenmp -Xcompiler -fopenmp-version=45
+      ALL_LDFLAGS += -Xcompiler -fopenmp -Xcompiler -fopenmp-version=45
+endif
+endif
+
 $(shell echo "#include <omp.h>" > test.c ; echo "int main() { omp_get_num_threads(); return 0; }" >> test.c ; $(HOST_COMPILER) -fopenmp test.c)
 OPENMP ?= $(shell find a.out 2>/dev/null)
 

--- a/Samples/0_Introduction/simpleMPI/Makefile
+++ b/Samples/0_Introduction/simpleMPI/Makefile
@@ -164,6 +164,10 @@ NVCCFLAGS   := -m${TARGET_SIZE}
 CCFLAGS     :=
 LDFLAGS     :=
 
+# Special treatment for Clang 
+ifneq (,$(findstring clang,$(HOST_COMPILER)))
+     CCFLAGS+= -fPIE
+endif
 # build flags
 ifeq ($(TARGET_OS),darwin)
     LDFLAGS += -rpath $(CUDA_PATH)/lib


### PR DESCRIPTION
Short:
Fixed compilation errors relating Clang 13 with OpenMP and MPI examples

Explanation:
- Fixed clang 13 OpenMP bug in cudaOpenMP and UnifiedMemoryStreams:
Check if we are running a clang compiler as Host-Compiler,
1. omit ```-lgomp``` / ```-lomp```
2. if clang 13 is found, add ```-Xcompiler -fopenmp-version=45```
- Fixed Bug in simpleMPI:
If we are using any clang compiler, use -fPIE for the compilation