### PR TITLE
bugfix: simpleVulkan now works on windows 10

### DIFF
--- a/Samples/5_Domain_Specific/simpleVulkan/VulkanBaseApp.cpp
+++ b/Samples/5_Domain_Specific/simpleVulkan/VulkanBaseApp.cpp
@@ -115,9 +115,12 @@ VulkanBaseApp::VulkanBaseApp(const std::string &appName, bool enableValidation)
 VkExternalSemaphoreHandleTypeFlagBits
 VulkanBaseApp::getDefaultSemaphoreHandleType() {
 #ifdef _WIN64
-  return IsWindows8OrGreater()
-             ? VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT
-             : VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT;
+  // "IsWindows8<xxx>orGreater" returns false on windows 10!
+  // https://docs.microsoft.com/en-us/windows/win32/sysinfo/version-helper-apis
+  //return IsWindows8OrGreater()
+  //           ? VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT
+  //           : VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT;
+  return VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
 #else
   return VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
 #endif /* _WIN64 */
@@ -125,9 +128,12 @@ VulkanBaseApp::getDefaultSemaphoreHandleType() {
 
 VkExternalMemoryHandleTypeFlagBits VulkanBaseApp::getDefaultMemHandleType() {
 #ifdef _WIN64
-  return IsWindows8Point1OrGreater()
-             ? VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT
-             : VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT;
+  // "IsWindows8<xxx>orGreater" returns false on windows 10!
+  // https://docs.microsoft.com/en-us/windows/win32/sysinfo/version-helper-apis
+  //return IsWindows8Point1OrGreater()
+  //           ? VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT
+  //           : VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT;
+  return VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
 #else
   return VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 #endif /* _WIN64 */

--- a/Samples/5_Domain_Specific/simpleVulkan/main.cpp
+++ b/Samples/5_Domain_Specific/simpleVulkan/main.cpp
@@ -345,6 +345,9 @@ class VulkanCudaSineWave : public VulkanBaseApp {
 
     externalMemoryHandleDesc.size = size;
 
+    // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#importing-memory-objects-vul-int
+    externalMemoryHandleDesc.flags |= cudaExternalMemoryDedicated;
+
 #ifdef _WIN64
     externalMemoryHandleDesc.handle.win32.handle =
         (HANDLE)getMemHandle(vkMem, handleType);


### PR DESCRIPTION
Bugfix #1:  added missing cudaExternalMemoryDedicated flag on cudaExternalMemoryHandleDesc
Bugfix #2:  IsWindows8<xxx>OrGreater queries return false on Windows 10. Always returning Windows 10 values now (might break on older Windows versions)