### PR TITLE
Fix: replace broken link

### DIFF
--- a/Samples/2_Concepts_and_Techniques/sortingNetworks/bitonicSort.cu
+++ b/Samples/2_Concepts_and_Techniques/sortingNetworks/bitonicSort.cu
@@ -25,7 +25,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-//Based on http://www.iti.fh-flensburg.de/lang/algorithmen/sortieren/bitonic/bitonicen.htm
+//Based on https://hwlang.de/algorithmen/sortieren/bitonic/bitonicen.htm
 
 #include <assert.h>
 #include <cooperative_groups.h>


### PR DESCRIPTION
The link explaining the sort was broken.
I updated the link to an equivalent (compared it via Wayback Machine). The new site is from the author of the post in the original link (Lang).