### PR TITLE
Remove unnecessary inheritance from `thrust::unary_function`

### DIFF
--- a/Samples/2_Concepts_and_Techniques/segmentationTreeThrust/kernels.cuh
+++ b/Samples/2_Concepts_and_Techniques/segmentationTreeThrust/kernels.cuh
@@ -34,13 +34,12 @@
 #define _KERNELS_H_
 
 #include <stdio.h>
-#include <thrust/functional.h>
 
 #include "common.cuh"
 
 // Functors used with thrust library.
 template <typename Input>
-struct IsGreaterEqualThan : public thrust::unary_function<Input, bool>
+struct IsGreaterEqualThan
 {
     __host__ __device__ IsGreaterEqualThan(uint upperBound) :
         upperBound_(upperBound) {}


### PR DESCRIPTION
fixes https://github.com/NVIDIA/cuda-samples/issues/328 

The need to inherit from `thrust::unary_function` was a hold-over from the pre-C++11 days. Nowadays, this isn't needed anymore and can just be removed. 