### PR TITLE
Fix the redeclaration against GLES2 and GLES3.

### DIFF
--- a/Common/GL/glext.h
+++ b/Common/GL/glext.h
@@ -3818,7 +3818,9 @@ typedef void (APIENTRYP PFNGLGETVERTEXATTRIBPOINTERVPROC)(GLuint index, GLenum p
 typedef GLboolean(APIENTRYP PFNGLISPROGRAMPROC)(GLuint program);
 typedef GLboolean(APIENTRYP PFNGLISSHADERPROC)(GLuint shader);
 typedef void (APIENTRYP PFNGLLINKPROGRAMPROC)(GLuint program);
+#if !defined(GL_ES_VERSION_2_0) && !defined(GL_ES_VERSION_3_0)
 typedef void (APIENTRYP PFNGLSHADERSOURCEPROC)(GLuint shader, GLsizei count, const GLchar **string, const GLint *length);
+#endif
 typedef void (APIENTRYP PFNGLUSEPROGRAMPROC)(GLuint program);
 typedef void (APIENTRYP PFNGLUNIFORM1FPROC)(GLint location, GLfloat v0);
 typedef void (APIENTRYP PFNGLUNIFORM2FPROC)(GLint location, GLfloat v0, GLfloat v1);


### PR DESCRIPTION
The following shows the error. 
```
cuda-samples/Samples/8_Platform_Specific/Tegra/simpleGLES_EGLOutput$ cmake .
-- The C compiler identification is GNU 13.3.0
-- The CXX compiler identification is GNU 13.3.0
-- The CUDA compiler identification is NVIDIA 12.8.93
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting CUDA compiler ABI info
-- Detecting CUDA compiler ABI info - done
-- Check for working CUDA compiler: /usr/local/cuda-12.8/bin/nvcc - skipped
-- Detecting CUDA compile features
-- Detecting CUDA compile features - done
-- Found CUDAToolkit: /usr/local/cuda-12.8/targets/x86_64-linux/include (found version "12.8.93") 
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Found EGL: /usr/lib/x86_64-linux-gnu/libEGL.so  
-- Found X11: /usr/include   
-- Looking for XOpenDisplay in /usr/lib/x86_64-linux-gnu/libX11.so
-- Looking for XOpenDisplay in /usr/lib/x86_64-linux-gnu/libX11.so - found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for connect
-- Looking for connect - found
-- Looking for remove
-- Looking for remove - found
-- Looking for shmat
-- Looking for shmat - found
-- Found OpenGL: /usr/lib/x86_64-linux-gnu/libOpenGL.so   
-- Configuring done (4.8s)
-- Generating done (0.0s)
-- Build files have been written to: /home/sylee/side/cuda-samples/Samples/8_Platform_Specific/Tegra/simpleGLES_EGLOutput

cuda-samples/Samples/8_Platform_Specific/Tegra/simpleGLES_EGLOutput$ make
[ 33%] Building CUDA object CMakeFiles/simpleGLES_EGLOutput.dir/simpleGLES_EGLOutput.cu.o
/home/sylee/side/cuda-samples/Samples/8_Platform_Specific/Tegra/simpleGLES_EGLOutput/graphics_interface_egloutput_via_egl.c(131): warning #68-D: integer conversion resulted in a change of sign
      uint32_t fb_id = -1;
                       ^

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"

/home/sylee/side/cuda-samples/Samples/8_Platform_Specific/Tegra/simpleGLES_EGLOutput/../../../../Common/GL/glext.h(3821): error: invalid redeclaration of type name "PFNGLSHADERSOURCEPROC" (declared at line 462 of /usr/include/GLES3/gl31.h)
  typedef void ( * PFNGLSHADERSOURCEPROC)(GLuint shader, GLsizei count, const GLchar **string, const GLint *length);
                   ^

1 error detected in the compilation of "/home/sylee/side/cuda-samples/Samples/8_Platform_Specific/Tegra/simpleGLES_EGLOutput/simpleGLES_EGLOutput.cu".
make[2]: *** [CMakeFiles/simpleGLES_EGLOutput.dir/build.make:77: CMakeFiles/simpleGLES_EGLOutput.dir/simpleGLES_EGLOutput.cu.o] Error 2
make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/simpleGLES_EGLOutput.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```