### PR TITLE
Adds missing helper header file

### DIFF
--- a/Samples/5_Domain_Specific/dxtc/CudaMath.h
+++ b/Samples/5_Domain_Specific/dxtc/CudaMath.h
@@ -31,6 +31,7 @@
 #define CUDAMATH_H
 
 #include <cooperative_groups.h>
+#include <helper_math.h>
 
 namespace cg = cooperative_groups;
 


### PR DESCRIPTION
CudaMath.h is missing float3 related header file. This PR adds missing helper_math.h file.