### PR TITLE
fix cmake build command with CUDA debug option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ in this configuration, hence it's not on by default. Enablement of on-device deb
 To enable cuda-gdb for samples builds, define the `ENABLE_CUDA_DEBUG` flag on the CMake command line. For example:
 
 ```
-cmake -DENABLE_CUDA_DEBUG=True ...
+cmake -DENABLE_CUDA_DEBUG=True ..
 ```
 
 ### Platform-Specific Samples


### PR DESCRIPTION
this does not work because of extra comma...

```console
root@tomoyafujita-B760M-Pro-RS-D4:~/docker_ws/CUDA/nvidia/cuda-samples/build# cmake -DENABLE_CUDA_DEBUG=True ...
CMake Error: The source directory "/root/docker_ws/CUDA/nvidia/cuda-samples/build/..." does not exist.
```