### PR TITLE
Remove unnecessary addition of 0.0f in vector addition

### DIFF
--- a/Samples/0_Introduction/vectorAdd/vectorAdd.cu
+++ b/Samples/0_Introduction/vectorAdd/vectorAdd.cu
@@ -49,7 +49,7 @@ __global__ void vectorAdd(const float *A, const float *B, float *C, int numEleme
     int i = blockDim.x * blockIdx.x + threadIdx.x;
 
     if (i < numElements) {
-        C[i] = A[i] + B[i] + 0.0f;
+        C[i] = A[i] + B[i];
     }
 }
 


### PR DESCRIPTION
I was going through the vectorAdd sample when I noticed 
the kernel computes A[i] + B[i] + 0.0f. 

Adding 0.0f has no effect on the result and looks . unintentional . possibly a leftover from an earlier 
edit. Removing it keeps the code clean since this .sample is widely read as a teaching reference.and the result of kernel should be identical before and after change.
