### PR TITLE
fix: add missing CUDA error check + correct Vulkan enum type mismatch

### DIFF
--- a/cpp/5_Domain_Specific/simpleVulkan/main.cpp
+++ b/cpp/5_Domain_Specific/simpleVulkan/main.cpp
@@ -328,13 +328,13 @@ public:
     {
         cudaExternalMemoryHandleDesc externalMemoryHandleDesc = {};
 
-        if (handleType & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT) {
+        if (handleType & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT) {
             externalMemoryHandleDesc.type = cudaExternalMemoryHandleTypeOpaqueWin32;
         }
-        else if (handleType & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT) {
+        else if (handleType & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT) {
             externalMemoryHandleDesc.type = cudaExternalMemoryHandleTypeOpaqueWin32Kmt;
         }
-        else if (handleType & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT) {
+        else if (handleType & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT) {
             externalMemoryHandleDesc.type = cudaExternalMemoryHandleTypeOpaqueFd;
         }
         else {

--- a/cpp/7_libNVVM/simple/simple.c
+++ b/cpp/7_libNVVM/simple/simple.c
@@ -69,7 +69,7 @@ static CUdevice cudaDeviceInit(int *devMajor, int *devMinor)
     CUdevice cuDevice = 0;
     checkCudaErrors(cuDeviceGet(&cuDevice, 0));
     char name[128];
-    cuDeviceGetName(name, sizeof(name), cuDevice);
+    checkCudaErrors(cuDeviceGetName(name, sizeof(name), cuDevice));
     printf("Using CUDA Device [0]: %s\n", name);
 
     // Obtain the device's compute capability.


### PR DESCRIPTION
## Summary

Two small fixes.

### 1. Missing error check on `cuDeviceGetName` (#413)

**File:** `cpp/7_libNVVM/simple/simple.c:72`

`cuDeviceGetName()` is called without `checkCudaErrors()`, so on failure the sample prints an uninitialised `name` buffer. Every other driver API call in `cudaDeviceInit()` is wrapped, so this just brings it in line.

### 2. Wrong Vulkan enum family in external memory import (#409)

**File:** `cpp/5_Domain_Specific/simpleVulkan/main.cpp:331-337`

`importCudaExternalMemory()` takes a `VkExternalMemoryHandleTypeFlagBits handleType`, but tests it against `VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_*` constants, which belong to `VkExternalSemaphoreHandleTypeFlagBits`. Replaced with the matching `VK_EXTERNAL_MEMORY_HANDLE_TYPE_*` constants.

This is a type correctness fix with no behavioural change, because the two enums use the same bit values:

| | memory | semaphore |
|---|---|---|
| `OPAQUE_FD_BIT` | 0x00000001 | 0x00000001 |
| `OPAQUE_WIN32_BIT` | 0x00000002 | 0x00000002 |
| `OPAQUE_WIN32_KMT_BIT` | 0x00000004 | 0x00000004 |

(An earlier version of this description said `VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT` was 0x00000001. That was wrong, it is 0x00000002. The values above are from `vulkan_core.h` in KhronosGroup/Vulkan-Headers.)

The other two `VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_*` sites in this file, at lines 369 and 379, are inside `importCudaExternalSemaphore()`, whose parameter really is `VkExternalSemaphoreHandleTypeFlagBits`. Those are correct and are deliberately left alone.

Fixes #413, Fixes #409