### PR TITLE
[fix] CMake 3.31+ breaks OpenMP detection in CUDA projects (issue #333)

### DIFF
--- a/Samples/0_Introduction/UnifiedMemoryStreams/CMakeLists.txt
+++ b/Samples/0_Introduction/UnifiedMemoryStreams/CMakeLists.txt
@@ -26,11 +26,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "QNX")
 endif()
 
 # Source file
-if(CMAKE_GENERATOR MATCHES "Visual Studio")
-    find_package(OpenMP REQUIRED C CXX)
-else()
-    find_package(OpenMP REQUIRED)
-endif()
+find_package(OpenMP REQUIRED C CXX)
 
 if(${OpenMP_FOUND})
     # Add target for UnifiedMemoryStreams

--- a/Samples/0_Introduction/cudaOpenMP/CMakeLists.txt
+++ b/Samples/0_Introduction/cudaOpenMP/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 # Include directories and libraries
 include_directories(../../../Common)
 
-find_package(OpenMP)
+find_package(OpenMP C CXX)
 
 # Source file
 if(OpenMP_CXX_FOUND)


### PR DESCRIPTION
## What's the problem

CMake 3.31 added support for finding OpenMP in the CUDA language. When `find_package(OpenMP)` (or `find_package(OpenMP REQUIRED)`) is called inside a project that declares `LANGUAGES C CXX CUDA`, CMake now also tries to find OpenMP for CUDA. That lookup fails on most setups because nvcc doesn't expose OpenMP the same way GCC/Clang does:

```
CMake Error at .../FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find OpenMP_CUDA (missing: OpenMP_CUDA_FLAGS OpenMP_CUDA_LIB_NAMES)
Call Stack:
  Samples/0_Introduction/UnifiedMemoryStreams/CMakeLists.txt:21 (find_package)
```

This hits anyone on CMake >= 3.31 building `UnifiedMemoryStreams` (and potentially `cudaOpenMP`) on Linux.

## Steps to reproduce

```bash
cmake -S . -B build   # CMake >= 3.31 required
```

Error appears when CMake processes `Samples/0_Introduction/UnifiedMemoryStreams/CMakeLists.txt`.

## What I changed

**`Samples/0_Introduction/UnifiedMemoryStreams/CMakeLists.txt`**

The Visual Studio branch already had `find_package(OpenMP REQUIRED C CXX)` — the non-VS branch was missing the language restriction. Since both cases want the same thing, I collapsed the `if/else` into a single call with `C CXX` specified:

```cmake
# before
if(CMAKE_GENERATOR MATCHES "Visual Studio")
    find_package(OpenMP REQUIRED C CXX)
else()
    find_package(OpenMP REQUIRED)
endif()

# after
find_package(OpenMP REQUIRED C CXX)
```

**`Samples/0_Introduction/cudaOpenMP/CMakeLists.txt`**

Same root cause. `find_package(OpenMP)` without components in a CUDA project will attempt CUDA OpenMP detection on CMake 3.31+. Added `C CXX` here too:

```cmake
# before
find_package(OpenMP)

# after
find_package(OpenMP C CXX)
```

## Why this is safe

Specifying `C CXX` explicitly tells CMake "only look for OpenMP for these two languages." This is exactly what these samples need — they link against `OpenMP::OpenMP_CXX` and never use CUDA OpenMP. The behavior is identical on CMake < 3.31 since CUDA was not a recognized OpenMP language before that version.

## Impact

Only affects the two sample CMakeLists files. No source code changes, no behavior change at runtime. Doesn't touch any other samples.

Fixes #333