### PR TITLE
fix(deviceQuery): compatibility fallback for removed system.get_driver_version() in newer cuda-core

### DIFF
--- a/python/1_GettingStarted/deviceQuery/deviceQuery.py
+++ b/python/1_GettingStarted/deviceQuery/deviceQuery.py
@@ -138,7 +138,16 @@ def print_device_info(dev_id, device):
     print(f"Device {dev_id}: {device.name}")
 
     # cuda.bindings workaround: runtime version not in cuda.core
-    driver_major, driver_minor = system.get_driver_version()
+    # system.get_driver_version() was removed in newer cuda-core versions;
+    # fall back to cuda.bindings.driver.cuDriverGetVersion()
+    if hasattr(system, "get_driver_version"):
+        driver_major, driver_minor = system.get_driver_version()
+    else:
+        err, driver_version_int = cuda.cuDriverGetVersion()
+        if err != cuda.CUresult.CUDA_SUCCESS:
+            raise RuntimeError(f"Failed to get CUDA driver version: {err}")
+        driver_major = driver_version_int // 1000
+        driver_minor = (driver_version_int % 1000) // 10
     err, runtime_version = cudart.cudaRuntimeGetVersion()
     if err != cudart.cudaError_t.cudaSuccess:
         raise RuntimeError(f"Failed to get CUDA runtime version: {err}")


### PR DESCRIPTION
system.get_driver_version() was removed from cuda.core.system in newer 
releases of the cuda-core package, causing deviceQuery.py to crash with:

  AttributeError: module 'cuda.core.system' has no attribute 'get_driver_version'

Fix: Added a hasattr() check. If the old API exists, it's used as before.
Otherwise, falls back to cuda.bindings.driver.cuDriverGetVersion() which
returns an integer (e.g. 13010) decoded as major=v//1000, minor=(v%1000)//10.

Tested on: NVIDIA GeForce RTX 3050 Laptop GPU
CUDA Driver 13.1 / Runtime 13.2, Windows 11
