### PR TITLE
Fix out-of-bounds TaskListPtr for last pthread worker in UnifiedMemoyStreams

### DIFF
--- a/cpp/0_Introduction/UnifiedMemoryStreams/UnifiedMemoryStreams.cu
+++ b/cpp/0_Introduction/UnifiedMemoryStreams/UnifiedMemoryStreams.cu
@@ -299,8 +299,7 @@ int main(int argc, char **argv)
         else {
             if (i == nthreads - 1) {
                 InputToThreads[i].taskSize = (TaskList.size() / nthreads) + (TaskList.size() % nthreads);
-                InputToThreads[i].TaskListPtr =
-                    &TaskList[i * (TaskList.size() / nthreads) + (TaskList.size() % nthreads)];
+                InputToThreads[i].TaskListPtr = &TaskList[i * (TaskList.size() / nthreads)];
             }
             else {
                 InputToThreads[i].taskSize    = (TaskList.size() / nthreads);


### PR DESCRIPTION
Fix: the starting offset for the last thread does not need the remainder term; only taskSize does.